### PR TITLE
Use platform 'ruby' for cross-platform compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,7 @@ GEM
     wahwah (1.3.0)
 
 PLATFORMS
-  arm64-darwin-20
-  arm64-darwin-21
+  ruby
 
 DEPENDENCIES
   cli-kit!


### PR DESCRIPTION
fix #1 